### PR TITLE
fault tolerance for messages without ruleId, line, or column

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -6,12 +6,12 @@ module.exports = function(results: CLIEngine.LintResult[]): string {
 
   for (const file of results.filter(r => r.messages.length > 0)) {
     for (const message of file.messages) {
-      const msg = `${message.message} (${message.ruleId})`;
+      const msg = message.message + (message.ruleId ? ` (${message.ruleId})` : '');
       const severity = message.fatal || message.severity === 2 ? 'error' : 'warning';
       const args = {
         file: file.filePath.substr(process.cwd().length+1),
-        line: message.line.toString(),
-        col: message.column.toString(),
+        line: message.line && message.line.toString(),
+        col: message.column && message.column.toString(),
       };
       issueCommand(severity, args, msg);
     }


### PR DESCRIPTION
When a file is ignored per the ESLint config, we get a message that looks like this:

```js
    {
      fatal: false,
      severity: 1,
      message: 'File ignored because of a matching ignore pattern. Use "--no-ignore" to override.'
    }
```

Which currently leads to an error because `message.line` is undefined. 

This change adds fault tolerance when the message does not have a ruleId, line, or column.